### PR TITLE
📝Add missing mapping class to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,5 @@ Please refer to the official [AHBicht docs](https://ahbicht.readthedocs.io/en/la
 
 ### Evaluation Results
 
+- [`AhbExpressionEvaluationResult`](https://ahbicht.readthedocs.io/en/latest/api/ahbicht.html?highlight=AhbExpressionEvaluationResult#ahbicht.evaluation_results.AhbExpressionEvaluationResult)
 - [`ContentEvaluationResult`](https://ahbicht.readthedocs.io/en/latest/api/ahbicht.content_evaluation.html?highlight=ContentEvaluationResult#ahbicht.content_evaluation.content_evaluation_result.ContentEvaluationResult)


### PR DESCRIPTION
this was missing due to a bug in the docs environment of ahbicht that has been resolved in https://github.com/Hochfrequenz/ahbicht/pull/186/